### PR TITLE
Skip referencing the secret elasticsearch-certs if .Values.elasticsea…

### DIFF
--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -49,9 +49,11 @@ spec:
       volumes:
         - name: kibana-tokens
           emptyDir: {}
+        {{- if .Values.elasticsearchCertificateSecret }}
         - name: elasticsearch-certs
           secret:
             secretName: {{ .Values.elasticsearchCertificateSecret }}
+        {{- end }}
         {{- if .Values.kibanaConfig }}
         - name: kibanaconfig
           configMap:
@@ -163,9 +165,11 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
+          {{- if .Values.elasticsearchCertificateSecret }}
           - name: elasticsearch-certs
             mountPath: {{ template "kibana.home_dir" . }}/config/certs
             readOnly: true
+          {{- end }}
           - name: kibana-tokens
             mountPath: {{ template "kibana.home_dir" . }}/config/tokens
             readOnly: true

--- a/kibana/templates/post-delete-job.yaml
+++ b/kibana/templates/post-delete-job.yaml
@@ -38,16 +38,20 @@ spec:
             - name: ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES
               value: "{{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }}"
           volumeMounts:
+            {{- if .Values.elasticsearchCertificateSecret }}
             - name: elasticsearch-certs
               mountPath: {{ template "kibana.home_dir" . }}/config/certs
               readOnly: true
+            {{- end }}
             - name: kibana-helm-scripts
               mountPath: {{ template "kibana.home_dir" . }}/helm-scripts
       serviceAccount: post-delete-{{ template "kibana.fullname" . }}
       volumes:
+        {{- if .Values.elasticsearchCertificateSecret }}
         - name: elasticsearch-certs
           secret:
             secretName: {{ .Values.elasticsearchCertificateSecret }}
+        {{- end }}
         - name: kibana-helm-scripts
           configMap:
             name: {{ template "kibana.fullname" . }}-helm-scripts

--- a/kibana/templates/pre-install-job.yaml
+++ b/kibana/templates/pre-install-job.yaml
@@ -38,16 +38,20 @@ spec:
             - name: ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES
               value: "{{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }}"
           volumeMounts:
+            {{- if .Values.elasticsearchCertificateSecret }}
             - name: elasticsearch-certs
               mountPath: {{ template "kibana.home_dir" . }}/config/certs
               readOnly: true
+            {{- end }}
             - name: kibana-helm-scripts
               mountPath: {{ template "kibana.home_dir" . }}/helm-scripts
       serviceAccount: pre-install-{{ template "kibana.fullname" . }}
       volumes:
+        {{- if .Values.elasticsearchCertificateSecret }}
         - name: elasticsearch-certs
           secret:
             secretName: {{ .Values.elasticsearchCertificateSecret }}
+        {{- end }}
         - name: kibana-helm-scripts
           configMap:
             name: {{ template "kibana.fullname" . }}-helm-scripts


### PR DESCRIPTION
…rchCertificateSecret is empty

Signed-off-by: Nobi <nobi@nobidev.com>

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
