### PR TITLE
Skip referencing the secret elasticsearch-certs if .Values.elasticsea…

### DIFF
--- a/kibana/templates/configmap-helm-scripts.yaml
+++ b/kibana/templates/configmap-helm-scripts.yaml
@@ -14,6 +14,7 @@ metadata:
     {{- end }}
 data:
   manage-es-token.js: |
+    const http = require('http');
     const https = require('https');
     const fs = require('fs');
 
@@ -31,8 +32,8 @@ data:
     const esUsername = getEnvVar('ELASTICSEARCH_USERNAME');
     const esPassword = getEnvVar('ELASTICSEARCH_PASSWORD');
     const esAuth = esUsername + ':' + esPassword;
-    const esCaFile = getEnvVar('ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES');
-    const esCa = fs.readFileSync(esCaFile);
+    const esCaFile = process.env['ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES'];
+    const esCa = esCaFile ? fs.readFileSync(esCaFile) : null;
 
     // Kubernetes API
     const k8sHostname = getEnvVar('KUBERNETES_SERVICE_HOST');
@@ -75,9 +76,9 @@ data:
     };
 
     // With thanks to https://stackoverflow.com/questions/57332374/how-to-chain-http-request
-    function requestPromise(url, httpsOptions, extraOptions = {}) {
+    function requestPromise(url, httpOptions, extraOptions = {}) {
       return new Promise((resolve, reject) => {
-        const request = https.request(url, httpsOptions, response => {
+        const request = (/^https:/.test(url) ? https : http).request(url, httpOptions, response => {
 
           console.log('statusCode:', response.statusCode);
 

--- a/kibana/templates/deployment.yaml
+++ b/kibana/templates/deployment.yaml
@@ -49,9 +49,11 @@ spec:
       volumes:
         - name: kibana-tokens
           emptyDir: {}
+        {{- if .Values.elasticsearchCertificateSecret }}
         - name: elasticsearch-certs
           secret:
             secretName: {{ .Values.elasticsearchCertificateSecret }}
+        {{- end }}
         {{- if .Values.kibanaConfig }}
         - name: kibanaconfig
           configMap:
@@ -163,9 +165,11 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
+          {{- if .Values.elasticsearchCertificateSecret }}
           - name: elasticsearch-certs
             mountPath: {{ template "kibana.home_dir" . }}/config/certs
             readOnly: true
+          {{- end }}
           - name: kibana-tokens
             mountPath: {{ template "kibana.home_dir" . }}/config/tokens
             readOnly: true

--- a/kibana/templates/post-delete-job.yaml
+++ b/kibana/templates/post-delete-job.yaml
@@ -38,16 +38,20 @@ spec:
             - name: ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES
               value: "{{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }}"
           volumeMounts:
+            {{- if .Values.elasticsearchCertificateSecret }}
             - name: elasticsearch-certs
               mountPath: {{ template "kibana.home_dir" . }}/config/certs
               readOnly: true
+            {{- end }}
             - name: kibana-helm-scripts
               mountPath: {{ template "kibana.home_dir" . }}/helm-scripts
       serviceAccount: post-delete-{{ template "kibana.fullname" . }}
       volumes:
+        {{- if .Values.elasticsearchCertificateSecret }}
         - name: elasticsearch-certs
           secret:
             secretName: {{ .Values.elasticsearchCertificateSecret }}
+        {{- end }}
         - name: kibana-helm-scripts
           configMap:
             name: {{ template "kibana.fullname" . }}-helm-scripts

--- a/kibana/templates/pre-install-job.yaml
+++ b/kibana/templates/pre-install-job.yaml
@@ -35,19 +35,25 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.elasticsearchCredentialSecret }}
                   key: password
+            {{- if .Values.elasticsearchCertificateSecret }}
             - name: ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES
               value: "{{ template "kibana.home_dir" . }}/config/certs/{{ .Values.elasticsearchCertificateAuthoritiesFile }}"
+            {{- end }}
           volumeMounts:
+            {{- if .Values.elasticsearchCertificateSecret }}
             - name: elasticsearch-certs
               mountPath: {{ template "kibana.home_dir" . }}/config/certs
               readOnly: true
+            {{- end }}
             - name: kibana-helm-scripts
               mountPath: {{ template "kibana.home_dir" . }}/helm-scripts
       serviceAccount: pre-install-{{ template "kibana.fullname" . }}
       volumes:
+        {{- if .Values.elasticsearchCertificateSecret }}
         - name: elasticsearch-certs
           secret:
             secretName: {{ .Values.elasticsearchCertificateSecret }}
+        {{- end }}
         - name: kibana-helm-scripts
           configMap:
             name: {{ template "kibana.fullname" . }}-helm-scripts


### PR DESCRIPTION
…rchCertificateSecret is empty

Signed-off-by: Nobi <nobi@nobidev.com>

- [ ] Chart version *not* bumped (the versions are all bumped and released at the same time)
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py` 
- [ ] Updated integration tests in `${CHART}/examples/*/test/goss.yaml`
